### PR TITLE
Added actions/action creators/reducers that update redux state when feathers service is changed in real time.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -212,12 +212,11 @@ const reduxifyService = (app, route, name = route, options = {}) => {
 
         { [ON_CREATED]: (state, action) => {
           debug(`redux:${ON_CREATED}`, action);
-          const { data } = action.payload;
           
           return {
             ...state,
             [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
-              data: state[opts.queryResult].data.concat(data),
+              data: state[opts.queryResult].data.concat(action.payload.data),
               total: state[opts.queryResult].total += 1
             }),
           };
@@ -225,14 +224,13 @@ const reduxifyService = (app, route, name = route, options = {}) => {
 
         { [ON_UPDATED]: (state, action) => {
           debug(`redux:${ON_UPDATED}`, action);
-          const { data } = action.payload;
 
           return {
             ...state,
             [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
               data: state[opts.queryResult].data.map(item => {
-                if (item.id === data.id) {
-                  return data;
+                if (item.id === action.payload.data.id) {
+                  return action.payload.data;
                 }
                 return item;
               }),
@@ -242,14 +240,13 @@ const reduxifyService = (app, route, name = route, options = {}) => {
         
         { [ON_PATCHED]: (state, action) => {
           debug(`redux:${ON_PATCHED}`, action);
-          const { data } = action.payload;
 
           return {
             ...state,
             [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
               data: state[opts.queryResult].data.map(item => {
-                if (item.id === data.id) {
-                  return data;
+                if (item.id === action.payload.data.id) {
+                  return action.payload.data;
                 }
                 return item;
               }),
@@ -259,8 +256,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
 
         { [ON_REMOVED]: (state, action) => {
           debug(`redux:${ON_REMOVED}`, action);
-          const { data } = action.payload;
-          const removeIndex = queryResult.data.findIndex(item => item.id === data.id);
+          const removeIndex = state.queryResult.data.findIndex(item => item.id === action.payload.data.id);
 
           return {
             ...state,

--- a/src/index.js
+++ b/src/index.js
@@ -155,7 +155,6 @@ const reduxifyService = (app, route, name = route, options = {}) => {
   const ON_PATCHED = `${SERVICE_NAME}ON_PATCHED`;
   const ON_REMOVED = `${SERVICE_NAME}ON_REMOVED`;
 
-
   const actionTypesForServiceMethod = (actionType) => ({
     [`${actionType}`]: `${actionType}`,
     [`${actionType}_${opts.PENDING}`]: `${actionType}_${opts.PENDING}`,
@@ -180,7 +179,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
     onUpdated: createAction(ON_UPDATED, (payload) => ({ data: payload })),
     onPatched: createAction(ON_PATCHED, (payload) => ({ data: payload })),
     onRemoved: createAction(ON_REMOVED, (payload) => ({ data: payload })),
-    
+
     // ACTION TYPES
 
     types: {
@@ -192,11 +191,11 @@ const reduxifyService = (app, route, name = route, options = {}) => {
       ...actionTypesForServiceMethod(REMOVE),
       RESET,
       STORE,
-  
+
       ...actionTypesForServiceMethod(ON_CREATED),
       ...actionTypesForServiceMethod(ON_UPDATED),
       ...actionTypesForServiceMethod(ON_PATCHED),
-      ...actionTypesForServiceMethod(ON_REMOVED),
+      ...actionTypesForServiceMethod(ON_REMOVED)
     },
 
     // REDUCER
@@ -212,13 +211,14 @@ const reduxifyService = (app, route, name = route, options = {}) => {
 
         { [ON_CREATED]: (state, action) => {
           debug(`redux:${ON_CREATED}`, action);
-          
+          const updatedResult = Object.assign({}, state[opts.queryResult], {
+            data: state[opts.queryResult].data.concat(action.payload.data),
+            total: state[opts.queryResult].total += 1
+          });
+
           return {
             ...state,
-            [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
-              data: state[opts.queryResult].data.concat(action.payload.data),
-              total: state[opts.queryResult].total += 1
-            }),
+            [opts.queryResult]: updatedResult
           };
         } },
 
@@ -233,11 +233,11 @@ const reduxifyService = (app, route, name = route, options = {}) => {
                   return action.payload.data;
                 }
                 return item;
-              }),
-            }),
+              })
+            })
           };
         } },
-        
+
         { [ON_PATCHED]: (state, action) => {
           debug(`redux:${ON_PATCHED}`, action);
 
@@ -249,8 +249,8 @@ const reduxifyService = (app, route, name = route, options = {}) => {
                   return action.payload.data;
                 }
                 return item;
-              }),
-            }),
+              })
+            })
           };
         } },
 
@@ -264,8 +264,8 @@ const reduxifyService = (app, route, name = route, options = {}) => {
               data: [
                 ...state[opts.queryResult].data.slice(0, removeIndex),
                 ...state[opts.queryResult].data.slice(removeIndex + 1)
-              ],
-            }),
+              ]
+            })
           };
         } },
 

--- a/src/index.js
+++ b/src/index.js
@@ -149,6 +149,13 @@ const reduxifyService = (app, route, name = route, options = {}) => {
   const RESET = `${SERVICE_NAME}RESET`;
   const STORE = `${SERVICE_NAME}STORE`;
 
+  // FEATHERS EVENT LISTENER ACTION TYPES
+  const ON_CREATED = `${SERVICE_NAME}ON_CREATED`;
+  const ON_UPDATED = `${SERVICE_NAME}ON_UPDATED`;
+  const ON_PATCHED = `${SERVICE_NAME}ON_PATCHED`;
+  const ON_REMOVED = `${SERVICE_NAME}ON_REMOVED`;
+
+
   const actionTypesForServiceMethod = (actionType) => ({
     [`${actionType}`]: `${actionType}`,
     [`${actionType}_${opts.PENDING}`]: `${actionType}_${opts.PENDING}`,
@@ -169,6 +176,11 @@ const reduxifyService = (app, route, name = route, options = {}) => {
     store: createAction(STORE, store => store),
     on: (event, data, fcn) => (dispatch, getState) => { fcn(event, data, dispatch, getState); },
 
+    onCreated: createAction(ON_CREATED, (payload) => ({ data: payload })),
+    onUpdated: createAction(ON_UPDATED, (payload) => ({ data: payload })),
+    onPatched: createAction(ON_PATCHED, (payload) => ({ data: payload })),
+    onRemoved: createAction(ON_REMOVED, (payload) => ({ data: payload })),
+    
     // ACTION TYPES
 
     types: {
@@ -179,7 +191,12 @@ const reduxifyService = (app, route, name = route, options = {}) => {
       ...actionTypesForServiceMethod(PATCH),
       ...actionTypesForServiceMethod(REMOVE),
       RESET,
-      STORE
+      STORE,
+  
+      ...actionTypesForServiceMethod(ON_CREATED),
+      ...actionTypesForServiceMethod(ON_UPDATED),
+      ...actionTypesForServiceMethod(ON_PATCHED),
+      ...actionTypesForServiceMethod(ON_REMOVED),
     },
 
     // REDUCER

--- a/src/index.js
+++ b/src/index.js
@@ -210,6 +210,69 @@ const reduxifyService = (app, route, name = route, options = {}) => {
         reducerForServiceMethod(PATCH, false),
         reducerForServiceMethod(REMOVE, false),
 
+        { [ON_CREATED]: (state, action) => {
+          debug(`redux:${ON_CREATED}`, action);
+          const { data } = action.payload;
+          
+          return {
+            ...state,
+            [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
+              data: state[opts.queryResult].data.concat(data),
+              total: state[opts.queryResult].total += 1
+            }),
+          };
+        } },
+
+        { [ON_UPDATED]: (state, action) => {
+          debug(`redux:${ON_UPDATED}`, action);
+          const { data } = action.payload;
+
+          return {
+            ...state,
+            [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
+              data: state[opts.queryResult].data.map(item => {
+                if (item.id === data.id) {
+                  return data;
+                }
+                return item;
+              }),
+            }),
+          };
+        } },
+        
+        { [ON_PATCHED]: (state, action) => {
+          debug(`redux:${ON_PATCHED}`, action);
+          const { data } = action.payload;
+
+          return {
+            ...state,
+            [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
+              data: state[opts.queryResult].data.map(item => {
+                if (item.id === data.id) {
+                  return data;
+                }
+                return item;
+              }),
+            }),
+          };
+        } },
+
+        { [ON_REMOVED]: (state, action) => {
+          debug(`redux:${ON_REMOVED}`, action);
+          const { data } = action.payload;
+          const removeIndex = queryResult.data.findIndex(item => item.id === data.id);
+
+          return {
+            ...state,
+            [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
+              data: [
+                ...state[opts.queryResult].data.slice(0, removeIndex),
+                ...state[opts.queryResult].data.slice(removeIndex + 1)
+              ],
+            }),
+          };
+        } },
+
         // reset status if no promise is pending
         { [RESET]: (state, action) => {
           debug(`redux:${RESET}`, action);


### PR DESCRIPTION
### Summary

Added the following combination of actions/reducers that update the redux state  accordingly when a particular feathers service data is changed in real time.
  ```
    // ACTION TYPES
  const ON_CREATED = `${SERVICE_NAME}ON_CREATED`;
  const ON_UPDATED = `${SERVICE_NAME}ON_UPDATED`;
  const ON_PATCHED = `${SERVICE_NAME}ON_PATCHED`;
  const ON_REMOVED = `${SERVICE_NAME}ON_REMOVED`;

    // ACTION CREATORS
    onCreated: createAction(ON_CREATED, (payload) => ({ data: payload })),
    onUpdated: createAction(ON_UPDATED, (payload) => ({ data: payload })),
    onPatched: createAction(ON_PATCHED, (payload) => ({ data: payload })),
    onRemoved: createAction(ON_REMOVED, (payload) => ({ data: payload })),

```
The actions above essentially update the queryResult object of the respective reducer/service. It works by dispatching the respective action within the service.on() method, for example:
```
  const task = feathersApp.service('/task');
    task.on('created', (data) => {
      dispatch(services.task.onCreated(data))    
    })
    task.on('updated', (data) => {
      dispatch(services.task.onUpdated(data))    
    })
    task.on('patched', (data) => {
      dispatch(services.task.onPatched(data))    
    })
    task.on('removed', (data) => {
      dispatch(services.task.onRemoved(data))    
    })
```