### PR TITLE
adds idField option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ and for string fragments in the action constants.
 The default is
 ```javascript
 { // Names of props for service's Redux state
+  idField: 'id',
   isError: 'isError', // e.g. state.messages.isError
   isLoading: 'isLoading',
   isSaving: 'isSaving',
@@ -267,6 +268,8 @@ In order for the redux store to update in realtime, these action dispatches shou
       dispatch(services.messages.onRemoved(data));
   })
 ```
+
+Note: `idField` is used to match events with correct objects.
 
 ## Action Pending/Loading
 

--- a/src/index.js
+++ b/src/index.js
@@ -71,6 +71,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
   debug(`route ${route}`);
 
   const defaults = {
+    idField: 'id',
     isError: 'isError',
     isLoading: 'isLoading',
     isSaving: 'isSaving',
@@ -258,7 +259,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
             ...state,
             [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
               data: state[opts.queryResult].data.map(item => {
-                if (item.id === action.payload.data.id) {
+                if (item[opts.idField] === action.payload.data[opts.idField]) {
                   return action.payload.data;
                 }
                 return item;
@@ -274,7 +275,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
             ...state,
             [opts.queryResult]: Object.assign({}, state[opts.queryResult], {
               data: state[opts.queryResult].data.map(item => {
-                if (item.id === action.payload.data.id) {
+                if (item[opts.idField] === action.payload.data[opts.idField]) {
                   return action.payload.data;
                 }
                 return item;
@@ -285,7 +286,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
 
         { [ON_REMOVED]: (state, action) => {
           debug(`redux:${ON_REMOVED}`, action);
-          const removeIndex = state.queryResult.data.findIndex(item => item.id === action.payload.data.id);
+          const removeIndex = state.queryResult.data.findIndex(item => item[opts.idField] === action.payload.data[opts.idField]);
           const updatedResult = Object.assign({}, state[opts.queryResult], {
             data: [
               ...state[opts.queryResult].data.slice(0, removeIndex),


### PR DESCRIPTION
Adds idField option to support id field names other than 'id'. Otherwise event reducers will not work correctly if id would be for example _id.