### PR TITLE
added conditional data state to resolved FULFILLED reducer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ const reduxifyService = (app, route, name = route, options = {}) => {
           [opts.isLoading]: false,
           [opts.isSaving]: false,
           [opts.isFinished]: true,
-          [opts.data]: !isFind ? action.payload : null,
+          [opts.data]: !isFind ? action.payload : (state[opts.data] || null),
           [opts.queryResult]: isFind ? action.payload : (state[opts.queryResult] || null),
           [opts[`${slicedActionType}Pending`]]: false
         };


### PR DESCRIPTION
Hey,
I ran into an issue regarding the reducer state:
1. initiated service create method.
2. handled the FULFILLED action in a saga by initiating service find method and navigation
3. on navigation the url params trigger services' get method
4. the find method replaced my data object from the get method. The flow from devtools:
SERVICE_X_FIND_PENDING,
SERVICE_X_GET_PENDING,
SERVICE_X_GET_FULFILLED: {... data: {my data object}, ... },
SERVICE_X_FIND_FULFILLED: {... data: null, ... }

Not sure if anyone would run into it, I just stumbled on it by accident (forgot to add a simple check).

Regards.